### PR TITLE
Changed buildTag to add wildcards before and after passed values.

### DIFF
--- a/chevalier-common.cabal
+++ b/chevalier-common.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                chevalier-common
-version:             0.2.0
+version:             0.2.1
 synopsis:            Common types for Chevalier
 license:             BSD3
 author:              Anchor Engineering <engineering@anchor.com.au>

--- a/lib/Chevalier/Util.hs
+++ b/lib/Chevalier/Util.hs
@@ -8,6 +8,7 @@ module Chevalier.Util where
 import qualified Data.ByteString as S
 import Data.HashMap.Strict(fromList)
 import Data.Locator
+import Data.Monoid
 import Data.ProtocolBuffers hiding (field)
 import Data.Serialize
 import Data.Text(splitOn, pack, unpack, append, Text)
@@ -35,7 +36,9 @@ buildRequestFromQuery (SourceQuery q address page page_size _ _) =
         a   -> Just $ fromIntegral $ fromBase62 $ unpack a
 
 buildTag :: Text -> Text -> SourceTag
-buildTag key value = SourceTag (putField key) (putField value)
+buildTag key value = SourceTag
+                     (putField key)
+                     (putField $ "*" <> value <> "*")
     
 decodeTag :: SourceTag -> (Text, Text)
 decodeTag (SourceTag key value) = (getField key, getField value)


### PR DESCRIPTION
Changes buildTag to allow 'regular' tag building (i.e. from a key+value) to match the structure of Sieste tag building (value only), in regards to creation of SourceRequests. Fixes Chevalier queries for Borel.
