### PR TITLE
Add strict key, wild value (called "fuzzy") requests

### DIFF
--- a/chevalier-common.cabal
+++ b/chevalier-common.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                chevalier-common
-version:             0.3.0
+version:             0.4.0
 synopsis:            Common types for Chevalier
 license:             BSD3
 author:              Anchor Engineering <engineering@anchor.com.au>


### PR DESCRIPTION
We now have strict requests (key, val), fuzzy requests `(key, *val*)` and wild requests `(*key*, *val*)`.

This isn't very nice, perhaps at some point it's worth a refactoring.
